### PR TITLE
seperate globals

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,39 +1,44 @@
-import time
+execGlobal=globals()
+
 import curses
 from ASnake import build, execPy, ASnakeVersion
 import subprocess
-
 import io
 from contextlib import redirect_stdout
-import platform
 
-compileDict={'CPython':'Python','PyPy':'PyPy3'}
 import sys
+import platform
+compileDict = {'CPython': 'Python', 'PyPy': 'PyPy3'}
+
 if hasattr(sys, "pyston_version_info"):
     # ^ Pyston dev's suggested this: https://github.com/pyston/pyston/issues/39
     # What scaredy cats!!
     compileTo = 'Pyston'
 else:
-    compileTo=compileDict[platform.python_implementation()]
-del sys
+    compileTo = compileDict[platform.python_implementation()]
+del sys, compileDict, platform
 
-ReplVersion='v0.2.0'
+ReplVersion = 'v0.2.1'
+
 
 # for debugging only
 def file_out(write_mode, *args):
-    with open("streams.txt", write_mode ,encoding = 'utf-8') as f:
+    with open("streams.txt", write_mode, encoding='utf-8') as f:
         f.write(f"{args}\n")
 
 
+def remove_char(word, idx):
+    return ''.join(x for x in word if word.index(x) != idx)
+
+
 def buildCode(code):
-    return build(code, comment=False, optimize=False, debug=False, compileTo=compileTo, pythonVersion=3.9, enforceTyping=True)
-    #return execPy(asn, fancy=False, pep=False, run=True, execTime=False, headless=False)
-    # return subprocess.run(["python3", "-c", asn], capture_output=True, text=True)
+    return build(code, comment=False, optimize=False, debug=False, compileTo=compileTo, pythonVersion=3.9,enforceTyping=True)
+
 
 bash_history = []
 
-def main(stdscr):
 
+def main(stdscr):
     # stdscr.nodelay(10)
     curses.use_default_colors()
     curses.init_pair(1, curses.COLOR_WHITE, -1)
@@ -46,37 +51,40 @@ def main(stdscr):
 
     while True:
         c = stdscr.getch()
+
+        # notetoself: x and y are cursor position
         y, x = stdscr.getyx()
         height, width = stdscr.getmaxyx()
 
         if c == curses.KEY_LEFT:
             if not x < 5:
-                stdscr.move(y, x-1) 
-            
-        elif c == curses.KEY_RIGHT:
-            stdscr.move(y, x+1)
+                stdscr.move(y, x - 1)
 
-        # todo 
+        elif c == curses.KEY_RIGHT:
+            stdscr.move(y, x + 1)
+
+        # todo -> bash history
         elif c == curses.KEY_UP:
-            pass 
+            pass
 
         elif c in {curses.KEY_BACKSPACE, 127}:
             if not x < 4:
                 stdscr.delch(y, x)
-                code = code[0:-1]
-                file_out("w", code)
+                code = remove_char(code, x - 4)
+                # file_out("a", code)
             else:
                 stdscr.move(y, x + 1)
 
         elif c in {curses.KEY_ENTER, 10, 13}:
-            if y >= height-1:
+            if y >= height - 1:
                 stdscr.clear()
                 stdscr.refresh()
             else:
-                stdscr.move(y+1,0)
+                stdscr.move(y + 1, 0)
                 with redirect_stdout(stdout):
-                    exec(buildCode(code))
-                output=stdout.getvalue()
+                    exec(buildCode(code),execGlobal)
+
+                output = stdout.getvalue()
                 # file_out("w", output.split("\n"), len(output.split("\n")))
                 out_arr = output.splitlines()
 
@@ -102,4 +110,6 @@ def main(stdscr):
     stdscr.refresh()
 
 
-curses.wrapper(main)
+if __name__ == "__main__":
+    curses.wrapper(main)
+


### PR DESCRIPTION
the REPL will now have its own globals() so that variables from the code don't leak into the REPL environment.
however, it seems to only prevent variables from inside the function. thus some of the imports still exist. deleting sys, compileDict, time, and platform to have less leakage.